### PR TITLE
Add minimal frontend for user list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
-# grapfrontend
+# Grap Frontend
+
+This is a minimal frontend application that fetches and displays a list of users from `/api/users`.
+
+## Development
+
+Open `index.html` in your browser. Ensure the backend exposing the `/api/users` endpoint is running on the same origin or configure CORS accordingly.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Grap Frontend</title>
+</head>
+<body>
+  <div id="root"></div>
+  <script src="https://unpkg.com/react@18/umd/react.development.js" crossorigin></script>
+  <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js" crossorigin></script>
+  <script type="module" src="./src/main.js"></script>
+</body>
+</html>

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,28 @@
+import React from 'https://esm.sh/react@18';
+import ReactDOM from 'https://esm.sh/react-dom@18';
+
+function App() {
+  const [users, setUsers] = React.useState([]);
+  const [loading, setLoading] = React.useState(true);
+  React.useEffect(() => {
+    fetch('/api/users')
+      .then(res => res.json())
+      .then(data => {
+        setUsers(data);
+        setLoading(false);
+      })
+      .catch(err => {
+        console.error('Failed to fetch users', err);
+        setLoading(false);
+      });
+  }, []);
+
+  if (loading) return React.createElement('p', null, 'Loading...');
+  return React.createElement('ul', null, users.map(user =>
+    React.createElement('li', { key: user.id }, `${user.name} (${user.email})`)
+  ));
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  React.createElement(App)
+);


### PR DESCRIPTION
## Summary
- add `index.html` with React CDN
- create `src/main.js` to fetch `/api/users`
- update README with usage notes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68888b10c12c832b8ea83b60dd5fdac7