### PR TITLE
Add simple auth, payment, tracking & settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,17 @@ provides placeholder screens for:
 - Porter service
 - Medicine delivery
 - Bike taxi service
+- User signup and login
+- Payment flow (simulated)
+- Driver location tracking
+- Customer settings for location and currency
 
 Open `index.html` in your browser to explore the different services. Each
 section is a minimal mock screen that demonstrates basic navigation between the
 home page and the individual services.
+
+Authentication, payment and tracking are simulated in-memory and do not reach
+any backend service.
 
 No build step is required as the app pulls React from a CDN. A backend is not
 needed for these placeholder screens.

--- a/src/main.js
+++ b/src/main.js
@@ -1,10 +1,11 @@
 import React from 'https://esm.sh/react@18';
 import ReactDOM from 'https://esm.sh/react-dom@18';
 
-function Home({ onNavigate }) {
+function Home({ onNavigate, user, onLogout }) {
   return (
     React.createElement('div', null,
       React.createElement('h1', null, 'Grab Style App'),
+      user ? React.createElement('p', null, `Welcome, ${user.username}`) : null,
       React.createElement('ul', null,
         React.createElement('li', null,
           React.createElement('button', { onClick: () => onNavigate('food') }, 'Restaurant Delivery')
@@ -23,6 +24,25 @@ function Home({ onNavigate }) {
         ),
         React.createElement('li', null,
           React.createElement('button', { onClick: () => onNavigate('bike') }, 'Bike Taxi')
+        ),
+        user ? React.createElement('li', null,
+          React.createElement('button', { onClick: () => onNavigate('payment') }, 'Payment')
+        ) : null,
+        user ? React.createElement('li', null,
+          React.createElement('button', { onClick: () => onNavigate('tracking') }, 'Track Driver')
+        ) : null,
+        React.createElement('li', null,
+          React.createElement('button', { onClick: () => onNavigate('settings') }, 'Settings')
+        ),
+        user ? React.createElement('li', null,
+          React.createElement('button', { onClick: onLogout }, 'Logout')
+        ) : React.createElement(React.Fragment, null,
+          React.createElement('li', null,
+            React.createElement('button', { onClick: () => onNavigate('login') }, 'Login')
+          ),
+          React.createElement('li', null,
+            React.createElement('button', { onClick: () => onNavigate('signup') }, 'Sign Up')
+          )
         )
       )
     )
@@ -31,6 +51,104 @@ function Home({ onNavigate }) {
 
 function BackButton({ onBack }) {
   return React.createElement('button', { onClick: onBack }, 'Back');
+}
+
+function Signup({ onBack, onSignup }) {
+  const [username, setUsername] = React.useState('');
+  const [password, setPassword] = React.useState('');
+  return React.createElement('div', null,
+    BackButton({ onBack }),
+    React.createElement('h2', null, 'Sign Up'),
+    React.createElement('input', {
+      placeholder: 'Username',
+      value: username,
+      onChange: e => setUsername(e.target.value)
+    }),
+    React.createElement('input', {
+      placeholder: 'Password',
+      type: 'password',
+      value: password,
+      onChange: e => setPassword(e.target.value)
+    }),
+    React.createElement('button', { onClick: () => onSignup({ username }) }, 'Sign Up')
+  );
+}
+
+function Login({ onBack, onLogin }) {
+  const [username, setUsername] = React.useState('');
+  const [password, setPassword] = React.useState('');
+  return React.createElement('div', null,
+    BackButton({ onBack }),
+    React.createElement('h2', null, 'Login'),
+    React.createElement('input', {
+      placeholder: 'Username',
+      value: username,
+      onChange: e => setUsername(e.target.value)
+    }),
+    React.createElement('input', {
+      placeholder: 'Password',
+      type: 'password',
+      value: password,
+      onChange: e => setPassword(e.target.value)
+    }),
+    React.createElement('button', { onClick: () => onLogin({ username }) }, 'Login')
+  );
+}
+
+function Settings({ onBack, settings, onUpdate }) {
+  const [location, setLocation] = React.useState(settings.location || '');
+  const [currency, setCurrency] = React.useState(settings.currency || 'USD');
+  return React.createElement('div', null,
+    BackButton({ onBack }),
+    React.createElement('h2', null, 'Customer Settings'),
+    React.createElement('div', null,
+      React.createElement('label', null, 'Location:'),
+      React.createElement('input', {
+        value: location,
+        onChange: e => setLocation(e.target.value)
+      })
+    ),
+    React.createElement('div', null,
+      React.createElement('label', null, 'Currency:'),
+      React.createElement('select', {
+        value: currency,
+        onChange: e => setCurrency(e.target.value)
+      },
+        React.createElement('option', { value: 'USD' }, 'USD'),
+        React.createElement('option', { value: 'EUR' }, 'EUR'),
+        React.createElement('option', { value: 'SGD' }, 'SGD')
+      )
+    ),
+    React.createElement('button', {
+      onClick: () => onUpdate({ location, currency })
+    }, 'Save')
+  );
+}
+
+function Payment({ onBack }) {
+  const handlePay = () => alert('Payment completed (simulated).');
+  return React.createElement('div', null,
+    BackButton({ onBack }),
+    React.createElement('h2', null, 'Payment'),
+    React.createElement('button', { onClick: handlePay }, 'Pay Now')
+  );
+}
+
+function OrderTracking({ onBack }) {
+  const [coords, setCoords] = React.useState({ lat: 1.29, lng: 103.85 });
+  React.useEffect(() => {
+    const id = setInterval(() => {
+      setCoords(c => ({ lat: c.lat + 0.001, lng: c.lng + 0.001 }));
+    }, 1000);
+    return () => clearInterval(id);
+  }, []);
+  const mapUrl = `https://maps.google.com/?q=${coords.lat},${coords.lng}&z=15&output=embed`;
+  return React.createElement('div', null,
+    BackButton({ onBack }),
+    React.createElement('h2', null, 'Driver Tracking'),
+    React.createElement('p', null, `Lat: ${coords.lat.toFixed(3)}, Lng: ${coords.lng.toFixed(3)}`),
+    React.createElement('iframe', { width: '100%', height: '300', src: mapUrl })
+  );
 }
 
 function FoodDelivery({ onBack }) {
@@ -83,10 +201,25 @@ function BikeTaxiService({ onBack }) {
 
 function App() {
   const [page, setPage] = React.useState('home');
+  const [user, setUser] = React.useState(null);
+  const [settings, setSettings] = React.useState({ location: '', currency: 'USD' });
 
   const onBack = () => setPage('home');
+  const handleAuth = u => { setUser(u); setPage('home'); };
+  const handleSettings = s => { setSettings(s); setPage('home'); };
+  const handleLogout = () => setUser(null);
 
   switch(page) {
+    case 'signup':
+      return Signup({ onBack, onSignup: handleAuth });
+    case 'login':
+      return Login({ onBack, onLogin: handleAuth });
+    case 'settings':
+      return Settings({ onBack, settings, onUpdate: handleSettings });
+    case 'payment':
+      return Payment({ onBack });
+    case 'tracking':
+      return OrderTracking({ onBack });
     case 'food':
       return FoodDelivery({ onBack });
     case 'taxi':
@@ -100,7 +233,7 @@ function App() {
     case 'bike':
       return BikeTaxiService({ onBack });
     default:
-      return Home({ onNavigate: setPage });
+      return Home({ onNavigate: setPage, user, onLogout: handleLogout });
   }
 }
 


### PR DESCRIPTION
## Summary
- extend README with new placeholder screens
- add signup/login/payment/tracking/settings components
- keep driver tracking on a simple map

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68888e135554832bb1f8e04d93af092e