### PR TITLE
Add booking forms for multi-service demo

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,24 @@
+# Super App Frontend Design
+
+This demo frontend bundles several on-demand services into a single page
+application. Each service has its own simple React component that captures basic
+information and calls `alert()` to simulate placing an order. The intention is
+to mimic the flow of popular services like ride hailing, food and grocery
+delivery within one lightweight app.
+
+## Components
+- **Home** – central menu that links to the other views
+- **Signup/Login** – minimal user authentication forms
+- **Settings** – stores user location and currency preferences in memory
+- **Payment** – simulated payment flow
+- **Order Tracking** – displays driver location updates using Leaflet
+- **Food Delivery** – fetches a list of restaurants from `/api/restaurants`
+- **Taxi Service** – book a car by specifying pickup and dropoff
+- **Bike Taxi Service** – quick motorcycle rides with the same flow
+- **Mart Delivery** – order an item and quantity
+- **Porter Service** – arrange package transport with pickup/dropoff addresses
+- **Medicine Delivery** – order medicine by name and quantity
+
+The app does not persist data or connect to real services. Instead it provides a
+clear structure for how multiple on-demand offerings could be organised in a
+single web app.

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ This is a simple single page application that mimics a Grab style user flow. It
 provides placeholder screens for:
 
 - Restaurant delivery with backend data
-- Taxi service
-- Mart delivery
-- Porter service
-- Medicine delivery
-- Bike taxi service
+- Taxi service with simple booking form
+- Mart delivery with item order form
+- Porter service with package booking form
+- Medicine delivery with quick medicine order
+- Bike taxi service with ride booking form
 - User signup and login
 - Payment flow (simulated)
 - Interactive driver location tracking map
@@ -16,6 +16,10 @@ provides placeholder screens for:
 
 The food delivery page fetches restaurant data from `/api/restaurants`. The
 driver tracking view polls `/api/driver` for current location updates.
+
+Each service page now includes a minimal form so you can simulate placing
+orders or booking rides directly in the browser. These actions simply trigger
+alerts but demonstrate the expected user flow for a combined super-app.
 
 Open `index.html` in your browser to explore the different services. Each
 section is a minimal mock screen that demonstrates basic navigation between the

--- a/src/main.js
+++ b/src/main.js
@@ -209,42 +209,146 @@ function FoodDelivery({ onBack }) {
 }
 
 function TaxiService({ onBack }) {
+  const [pickup, setPickup] = React.useState('');
+  const [dropoff, setDropoff] = React.useState('');
+  const book = () => {
+    alert(`Taxi booked from ${pickup} to ${dropoff}`);
+    setPickup('');
+    setDropoff('');
+  };
   return React.createElement('div', null,
     BackButton({ onBack }),
     React.createElement('h2', null, 'Taxi Service'),
-    React.createElement('p', null, 'Book a taxi to your destination.')
+    React.createElement('div', null,
+      React.createElement('input', {
+        placeholder: 'Pick-up location',
+        value: pickup,
+        onChange: e => setPickup(e.target.value)
+      }),
+      React.createElement('input', {
+        placeholder: 'Drop-off location',
+        value: dropoff,
+        onChange: e => setDropoff(e.target.value)
+      }),
+      React.createElement('button', { onClick: book }, 'Book Taxi')
+    )
   );
 }
 
 function MartDelivery({ onBack }) {
+  const [item, setItem] = React.useState('');
+  const [quantity, setQuantity] = React.useState('1');
+  const order = () => {
+    alert(`Ordered ${quantity} x ${item}`);
+    setItem('');
+    setQuantity('1');
+  };
   return React.createElement('div', null,
     BackButton({ onBack }),
     React.createElement('h2', null, 'Mart Delivery'),
-    React.createElement('p', null, 'Get groceries and daily needs delivered.')
+    React.createElement('div', null,
+      React.createElement('input', {
+        placeholder: 'Item',
+        value: item,
+        onChange: e => setItem(e.target.value)
+      }),
+      React.createElement('input', {
+        type: 'number',
+        min: 1,
+        value: quantity,
+        onChange: e => setQuantity(e.target.value)
+      }),
+      React.createElement('button', { onClick: order }, 'Place Order')
+    )
   );
 }
 
 function PorterService({ onBack }) {
+  const [pickup, setPickup] = React.useState('');
+  const [dropoff, setDropoff] = React.useState('');
+  const [description, setDescription] = React.useState('');
+  const book = () => {
+    alert(`Porter booked: ${description} from ${pickup} to ${dropoff}`);
+    setPickup('');
+    setDropoff('');
+    setDescription('');
+  };
   return React.createElement('div', null,
     BackButton({ onBack }),
     React.createElement('h2', null, 'Porter Service'),
-    React.createElement('p', null, 'Send packages and documents across town.')
+    React.createElement('div', null,
+      React.createElement('input', {
+        placeholder: 'Package description',
+        value: description,
+        onChange: e => setDescription(e.target.value)
+      }),
+      React.createElement('input', {
+        placeholder: 'Pick-up address',
+        value: pickup,
+        onChange: e => setPickup(e.target.value)
+      }),
+      React.createElement('input', {
+        placeholder: 'Drop-off address',
+        value: dropoff,
+        onChange: e => setDropoff(e.target.value)
+      }),
+      React.createElement('button', { onClick: book }, 'Book Porter')
+    )
   );
 }
 
 function MedicineDelivery({ onBack }) {
+  const [medicine, setMedicine] = React.useState('');
+  const [quantity, setQuantity] = React.useState('1');
+  const order = () => {
+    alert(`Ordered ${quantity} x ${medicine}`);
+    setMedicine('');
+    setQuantity('1');
+  };
   return React.createElement('div', null,
     BackButton({ onBack }),
     React.createElement('h2', null, 'Medicine Delivery'),
-    React.createElement('p', null, 'Order medicines and health products.')
+    React.createElement('div', null,
+      React.createElement('input', {
+        placeholder: 'Medicine name',
+        value: medicine,
+        onChange: e => setMedicine(e.target.value)
+      }),
+      React.createElement('input', {
+        type: 'number',
+        min: 1,
+        value: quantity,
+        onChange: e => setQuantity(e.target.value)
+      }),
+      React.createElement('button', { onClick: order }, 'Order Now')
+    )
   );
 }
 
 function BikeTaxiService({ onBack }) {
+  const [pickup, setPickup] = React.useState('');
+  const [dropoff, setDropoff] = React.useState('');
+  const book = () => {
+    alert(`Bike taxi booked from ${pickup} to ${dropoff}`);
+    setPickup('');
+    setDropoff('');
+  };
   return React.createElement('div', null,
     BackButton({ onBack }),
     React.createElement('h2', null, 'Bike Taxi Service'),
-    React.createElement('p', null, 'Quick two-wheeler rides around the city.')
+    React.createElement('div', null,
+      React.createElement('input', {
+        placeholder: 'Pick-up point',
+        value: pickup,
+        onChange: e => setPickup(e.target.value)
+      }),
+      React.createElement('input', {
+        placeholder: 'Drop-off point',
+        value: dropoff,
+        onChange: e => setDropoff(e.target.value)
+      }),
+      React.createElement('button', { onClick: book }, 'Book Ride')
+    )
   );
 }
 


### PR DESCRIPTION
## Summary
- add simple forms to book taxis, bikes, porter, mart, and medicine
- update README with new form-based services
- document overall design in DESIGN.md

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_68889372472c832bbca642091145eebe