### PR TITLE
Add Express backend with API routes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "grapfrontend-server",
+  "version": "1.0.0",
+  "description": "Backend server for Grap Frontend demo",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}

--- a/routes/driver.js
+++ b/routes/driver.js
@@ -1,0 +1,19 @@
+const express = require('express');
+const router = express.Router();
+
+let lat = 1.29;
+let lng = 103.85;
+
+function move() {
+  const deltaLat = (Math.random() - 0.5) * 0.001;
+  const deltaLng = (Math.random() - 0.5) * 0.001;
+  lat += deltaLat;
+  lng += deltaLng;
+}
+
+router.get('/', (req, res) => {
+  move();
+  res.json({ lat, lng });
+});
+
+module.exports = router;

--- a/routes/restaurants.js
+++ b/routes/restaurants.js
@@ -1,0 +1,14 @@
+const express = require('express');
+const router = express.Router();
+
+const sampleRestaurants = [
+  { id: 1, name: 'Pizza Palace' },
+  { id: 2, name: 'Sushi Central' },
+  { id: 3, name: 'Burger Hub' }
+];
+
+router.get('/', (req, res) => {
+  res.json(sampleRestaurants);
+});
+
+module.exports = router;

--- a/server.js
+++ b/server.js
@@ -1,0 +1,16 @@
+const express = require('express');
+const path = require('path');
+const app = express();
+
+const restaurants = require('./routes/restaurants');
+const driver = require('./routes/driver');
+
+app.use(express.static(path.join(__dirname)));
+
+app.use('/api/restaurants', restaurants);
+app.use('/api/driver', driver);
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- create basic `server.js` with Express
- add API routes in `routes/` for restaurants and driver location
- provide `package.json` and `.gitignore`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68889483d7b8832b866af0b0a75fca85