### PR TITLE
Add cart and checkout flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,12 @@ provides placeholder screens for:
 - Bike taxi service with ride booking form
 - User signup and login
 - Payment flow (simulated)
+- Simple cart with checkout
 - Interactive driver location tracking map
 - Customer settings for location and currency
+
+Items selected from the service screens can be added to a small in-memory cart.
+The cart page allows reviewing items and leads to the simulated payment flow.
 
 The food delivery page fetches restaurant data from `/api/restaurants`. The
 driver tracking view polls `/api/driver` for current location updates.


### PR DESCRIPTION
## Summary
- add simple cart page and update payment to list items
- enable adding items from food, mart and medicine screens
- wire up cart state and new checkout flow for web and Expo
- document the new cart feature

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688898bf1a74832bb00acca023e2f08c