### PR TITLE
Add order tracking screen

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -11,6 +11,7 @@ delivery within one lightweight app.
 - **Signup/Login** – minimal user authentication forms
 - **Settings** – stores user location and currency preferences in memory
 - **Payment** – simulated payment flow
+- **Orders** – view a list of previously paid orders
 - **Order Tracking** – displays driver location updates using Leaflet
 - **Food Delivery** – fetches a list of restaurants from `/api/restaurants`
 - **Taxi Service** – book a car by specifying pickup and dropoff

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ provides placeholder screens for:
 - User signup and login
 - Payment flow (simulated)
 - Simple cart with checkout
+- Order history screen
 - Interactive driver location tracking map
 - Customer settings for location and currency
 

--- a/src/main.js
+++ b/src/main.js
@@ -10,6 +10,7 @@ import MartScreen from "./screens/MartScreen.js";
 import PorterScreen from "./screens/PorterScreen.js";
 import MedicineScreen from "./screens/MedicineScreen.js";
 import BikeTaxiScreen from "./screens/BikeTaxiScreen.js";
+import OrdersScreen from "./screens/OrdersScreen.js";
 import BackButton from "./components/BackButton.js";
 
 function Signup({ onBack, onSignup }) {
@@ -113,6 +114,7 @@ function App() {
   const [user, setUser] = React.useState(null);
   const [settings, setSettings] = React.useState({ location: '', currency: 'USD' });
   const [cart, setCart] = React.useState([]);
+  const [orders, setOrders] = React.useState([]);
 
   const addToCart = item => setCart(c => [...c, item]);
   const removeFromCart = idx => setCart(c => c.filter((_, i) => i !== idx));
@@ -131,11 +133,17 @@ function App() {
     case 'settings':
       return Settings({ onBack, settings, onUpdate: handleSettings });
     case 'payment':
-      return PaymentScreen({ onBack, items: cart, onPay: () => { clearCart(); setPage('home'); } });
+      return PaymentScreen({ onBack, items: cart, onPay: () => {
+        setOrders(o => [...o, { id: Date.now(), items: cart, status: 'Pending' }]);
+        clearCart();
+        setPage('orders');
+      } });
     case 'cart':
       return Cart({ onBack, items: cart, onCheckout: () => setPage('payment'), onRemove: removeFromCart });
     case 'tracking':
       return TrackingScreen({ onBack });
+    case 'orders':
+      return OrdersScreen({ onBack, orders });
     case 'food':
       return FoodDeliveryScreen({ onBack, onAdd: addToCart });
     case 'taxi':

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -30,6 +30,9 @@ export default function HomeScreen({ onNavigate, user, onLogout }) {
         user ? React.createElement('li', null,
           React.createElement('button', { onClick: () => onNavigate('tracking') }, 'Track Driver')
         ) : null,
+        user ? React.createElement('li', null,
+          React.createElement('button', { onClick: () => onNavigate('orders') }, 'My Orders')
+        ) : null,
         React.createElement('li', null,
           React.createElement('button', { onClick: () => onNavigate('settings') }, 'Settings')
         ),

--- a/src/screens/OrdersScreen.js
+++ b/src/screens/OrdersScreen.js
@@ -1,0 +1,18 @@
+import React from 'https://esm.sh/react@18';
+import BackButton from '../components/BackButton.js';
+
+export default function OrdersScreen({ onBack, orders }) {
+  return React.createElement('div', null,
+    BackButton({ onBack }),
+    React.createElement('h2', null, 'Your Orders'),
+    orders.length
+      ? React.createElement('ul', null,
+          orders.map(order =>
+            React.createElement('li', { key: order.id },
+              `Order #${order.id} - ${order.status}`
+            )
+          )
+        )
+      : React.createElement('p', null, 'No orders yet')
+  );
+}


### PR DESCRIPTION
## Summary
- introduce a new **Orders** screen to list completed orders
- track paid orders and show them from Home
- add navigation to `Orders` from Home
- document new Orders screen in README and DESIGN

## Testing
- `npm install`
- `node server.js` *(works)*

------
https://chatgpt.com/codex/tasks/task_e_68889cc6d040832b8cf6e5db32090716