### PR TITLE
Add orders API and integrate frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,10 @@ Open `index.html` in your browser to explore the different services. Each
 section is a minimal mock screen that demonstrates basic navigation between the
 home page and the individual services.
 
-Authentication and payment remain simulated in-memory, but the driver tracking
-screen now requests location updates from your backend. The frontend expects an
-endpoint at `/api/driver` that returns JSON with `lat` and `lng` values.
+Authentication remains simulated, but orders are now persisted on the backend.
+After checking out, the cart items are sent to `/api/orders` which stores the
+order in memory. The driver tracking screen requests location updates from your
+backend at `/api/driver`.
 
 No build step is required as the app still pulls React and other libraries from
 CDNs.
@@ -47,4 +48,4 @@ npm install
 npx expo start
 ```
 
-The API endpoints from the Node server should remain accessible for restaurant data and driver tracking.
+The API endpoints from the Node server should remain accessible for restaurant data, order storage and driver tracking.

--- a/routes/orders.js
+++ b/routes/orders.js
@@ -1,0 +1,21 @@
+const express = require('express');
+const router = express.Router();
+
+let orders = [];
+let idCounter = 1;
+
+router.get('/', (req, res) => {
+  res.json(orders);
+});
+
+router.post('/', (req, res) => {
+  const { items } = req.body;
+  if (!Array.isArray(items) || !items.length) {
+    return res.status(400).json({ error: 'Invalid order' });
+  }
+  const order = { id: idCounter++, items, status: 'Pending' };
+  orders.push(order);
+  res.status(201).json(order);
+});
+
+module.exports = router;

--- a/server.js
+++ b/server.js
@@ -4,11 +4,14 @@ const app = express();
 
 const restaurants = require('./routes/restaurants');
 const driver = require('./routes/driver');
+const orders = require('./routes/orders');
 
 app.use(express.static(path.join(__dirname)));
+app.use(express.json());
 
 app.use('/api/restaurants', restaurants);
 app.use('/api/driver', driver);
+app.use('/api/orders', orders);
 
 const PORT = process.env.PORT || 3000;
 app.listen(PORT, () => {

--- a/src/main.js
+++ b/src/main.js
@@ -114,7 +114,6 @@ function App() {
   const [user, setUser] = React.useState(null);
   const [settings, setSettings] = React.useState({ location: '', currency: 'USD' });
   const [cart, setCart] = React.useState([]);
-  const [orders, setOrders] = React.useState([]);
 
   const addToCart = item => setCart(c => [...c, item]);
   const removeFromCart = idx => setCart(c => c.filter((_, i) => i !== idx));
@@ -134,7 +133,6 @@ function App() {
       return Settings({ onBack, settings, onUpdate: handleSettings });
     case 'payment':
       return PaymentScreen({ onBack, items: cart, onPay: () => {
-        setOrders(o => [...o, { id: Date.now(), items: cart, status: 'Pending' }]);
         clearCart();
         setPage('orders');
       } });
@@ -143,7 +141,7 @@ function App() {
     case 'tracking':
       return TrackingScreen({ onBack });
     case 'orders':
-      return OrdersScreen({ onBack, orders });
+      return OrdersScreen({ onBack });
     case 'food':
       return FoodDeliveryScreen({ onBack, onAdd: addToCart });
     case 'taxi':

--- a/src/screens/OrdersScreen.js
+++ b/src/screens/OrdersScreen.js
@@ -1,7 +1,24 @@
 import React from 'https://esm.sh/react@18';
 import BackButton from '../components/BackButton.js';
 
-export default function OrdersScreen({ onBack, orders }) {
+export default function OrdersScreen({ onBack }) {
+  const [orders, setOrders] = React.useState([]);
+
+  React.useEffect(() => {
+    const load = async () => {
+      try {
+        const res = await fetch('/api/orders');
+        if (res.ok) {
+          const data = await res.json();
+          setOrders(data);
+        }
+      } catch (e) {
+        console.error('Failed to load orders', e);
+      }
+    };
+    load();
+  }, []);
+
   return React.createElement('div', null,
     BackButton({ onBack }),
     React.createElement('h2', null, 'Your Orders'),

--- a/src/screens/PaymentScreen.js
+++ b/src/screens/PaymentScreen.js
@@ -2,9 +2,22 @@ import React from 'https://esm.sh/react@18';
 import BackButton from '../components/BackButton.js';
 
 export default function PaymentScreen({ onBack, items, onPay }) {
-  const handlePay = () => {
-    alert('Payment completed (simulated).');
-    onPay();
+  const handlePay = async () => {
+    try {
+      const res = await fetch('/api/orders', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ items })
+      });
+      if (!res.ok) {
+        throw new Error('Failed to place order');
+      }
+      alert('Payment completed. Order placed!');
+      onPay();
+    } catch (e) {
+      console.error(e);
+      alert('Payment failed.');
+    }
   };
   return React.createElement('div', null,
     BackButton({ onBack }),


### PR DESCRIPTION
## Summary
- store orders on the backend
- POST cart contents from the payment screen
- load orders from the server in the orders screen
- wire up new `/api/orders` route and enable JSON parsing
- document the new orders endpoint

## Testing
- `npm install`
- `node server.js` *(fails: cannot find module 'express')*
- `npm install`
- `node server.js`

------
https://chatgpt.com/codex/tasks/task_e_6888a13dffa0832b9ba0ea227193cf62