### PR TITLE
Implement direct checkout flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,10 @@ The food delivery page fetches restaurant data from `/api/restaurants`. The
 driver tracking view polls `/api/driver` for current location updates.
 
 Each service page now includes a minimal form so you can simulate placing
-orders or booking rides directly in the browser. These actions simply trigger
-alerts but demonstrate the expected user flow for a combined super-app.
+orders or booking rides directly in the browser. After selecting a service the
+app immediately redirects to the payment screen with the chosen item so the
+flow mirrors a real checkout. Drivers are "notified" via on-screen alerts when
+a ride or delivery is booked.
 
 Open `index.html` in your browser to explore the different services. Each
 section is a minimal mock screen that demonstrates basic navigation between the

--- a/src/main.js
+++ b/src/main.js
@@ -118,6 +118,7 @@ function App() {
   const addToCart = item => setCart(c => [...c, item]);
   const removeFromCart = idx => setCart(c => c.filter((_, i) => i !== idx));
   const clearCart = () => setCart([]);
+  const checkoutItem = item => { setCart([item]); setPage('payment'); };
 
   const onBack = () => setPage('home');
   const handleAuth = u => { setUser(u); setPage('home'); };
@@ -143,17 +144,17 @@ function App() {
     case 'orders':
       return OrdersScreen({ onBack });
     case 'food':
-      return FoodDeliveryScreen({ onBack, onAdd: addToCart });
+      return FoodDeliveryScreen({ onBack, onOrder: checkoutItem });
     case 'taxi':
-      return TaxiScreen({ onBack });
+      return TaxiScreen({ onBack, onOrder: checkoutItem });
     case 'mart':
-      return MartScreen({ onBack, onAdd: addToCart });
+      return MartScreen({ onBack, onOrder: checkoutItem });
     case 'porter':
-      return PorterScreen({ onBack });
+      return PorterScreen({ onBack, onOrder: checkoutItem });
     case 'medicine':
-      return MedicineScreen({ onBack, onAdd: addToCart });
+      return MedicineScreen({ onBack, onOrder: checkoutItem });
     case 'bike':
-      return BikeTaxiScreen({ onBack });
+      return BikeTaxiScreen({ onBack, onOrder: checkoutItem });
     default:
       return HomeScreen({ onNavigate: setPage, user, onLogout: handleLogout });
   }

--- a/src/screens/BikeTaxiScreen.js
+++ b/src/screens/BikeTaxiScreen.js
@@ -1,14 +1,28 @@
 import React from 'https://esm.sh/react@18';
 import BackButton from '../components/BackButton.js';
 
-export default function BikeTaxiScreen({ onBack }) {
+export default function BikeTaxiScreen({ onBack, onOrder }) {
   const [pickup, setPickup] = React.useState('');
   const [dropoff, setDropoff] = React.useState('');
-  const book = () => {
-    alert(`Bike taxi booked from ${pickup} to ${dropoff}`);
+  const [showOptions, setShowOptions] = React.useState(false);
+  const bikes = [
+    { id: 1, type: 'Standard', price: 5 },
+    { id: 2, type: 'Premium', price: 8 }
+  ];
+
+  const search = () => {
+    if (!pickup || !dropoff) return;
+    setShowOptions(true);
+  };
+
+  const choose = b => {
+    alert(`${b.type} rider notified!`);
+    onOrder({ name: `${b.type} bike ride`, qty: 1, price: b.price });
     setPickup('');
     setDropoff('');
+    setShowOptions(false);
   };
+
   return React.createElement('div', null,
     BackButton({ onBack }),
     React.createElement('h2', null, 'Bike Taxi Service'),
@@ -23,7 +37,18 @@ export default function BikeTaxiScreen({ onBack }) {
         value: dropoff,
         onChange: e => setDropoff(e.target.value)
       }),
-      React.createElement('button', { onClick: book }, 'Book Ride')
+      React.createElement('button', { onClick: search }, 'Find Ride')
+    ),
+    showOptions && React.createElement('div', { style: { marginTop: '1em' } },
+      React.createElement('p', null, 'Distance 5km, ETA 15min (simulated)'),
+      React.createElement('ul', null,
+        bikes.map(b =>
+          React.createElement('li', { key: b.id },
+            `${b.type} - $${b.price} `,
+            React.createElement('button', { onClick: () => choose(b) }, 'Select')
+          )
+        )
+      )
     )
   );
 }

--- a/src/screens/FoodDeliveryScreen.js
+++ b/src/screens/FoodDeliveryScreen.js
@@ -1,7 +1,7 @@
 import React from 'https://esm.sh/react@18';
 import BackButton from '../components/BackButton.js';
 
-export default function FoodDeliveryScreen({ onBack, onAdd }) {
+export default function FoodDeliveryScreen({ onBack, onOrder }) {
   const [restaurants, setRestaurants] = React.useState([]);
 
   React.useEffect(() => {
@@ -28,7 +28,7 @@ export default function FoodDeliveryScreen({ onBack, onAdd }) {
             React.createElement('li', { key: r.id },
               r.name,
               ' ',
-              React.createElement('button', { onClick: () => onAdd({ name: r.name, qty: 1 }) }, 'Add')
+              React.createElement('button', { onClick: () => onOrder({ name: r.name, qty: 1, price: 12 }) }, 'Order')
             )
           )
         )

--- a/src/screens/MartScreen.js
+++ b/src/screens/MartScreen.js
@@ -1,12 +1,12 @@
 import React from 'https://esm.sh/react@18';
 import BackButton from '../components/BackButton.js';
 
-export default function MartScreen({ onBack, onAdd }) {
+export default function MartScreen({ onBack, onOrder }) {
   const [item, setItem] = React.useState('');
   const [quantity, setQuantity] = React.useState('1');
   const add = () => {
     if (!item) return;
-    onAdd({ name: item, qty: quantity });
+    onOrder({ name: item, qty: quantity, price: 5 });
     setItem('');
     setQuantity('1');
   };
@@ -25,7 +25,7 @@ export default function MartScreen({ onBack, onAdd }) {
         value: quantity,
         onChange: e => setQuantity(e.target.value)
       }),
-      React.createElement('button', { onClick: add }, 'Add to Cart')
+      React.createElement('button', { onClick: add }, 'Checkout')
     )
   );
 }

--- a/src/screens/MedicineScreen.js
+++ b/src/screens/MedicineScreen.js
@@ -1,12 +1,12 @@
 import React from 'https://esm.sh/react@18';
 import BackButton from '../components/BackButton.js';
 
-export default function MedicineScreen({ onBack, onAdd }) {
+export default function MedicineScreen({ onBack, onOrder }) {
   const [medicine, setMedicine] = React.useState('');
   const [quantity, setQuantity] = React.useState('1');
   const add = () => {
     if (!medicine) return;
-    onAdd({ name: medicine, qty: quantity });
+    onOrder({ name: medicine, qty: quantity, price: 8 });
     setMedicine('');
     setQuantity('1');
   };
@@ -25,7 +25,7 @@ export default function MedicineScreen({ onBack, onAdd }) {
         value: quantity,
         onChange: e => setQuantity(e.target.value)
       }),
-      React.createElement('button', { onClick: add }, 'Add to Cart')
+      React.createElement('button', { onClick: add }, 'Checkout')
     )
   );
 }

--- a/src/screens/PaymentScreen.js
+++ b/src/screens/PaymentScreen.js
@@ -25,7 +25,12 @@ export default function PaymentScreen({ onBack, items, onPay }) {
     items.length
       ? React.createElement('ul', null,
           items.map((it, idx) =>
-            React.createElement('li', { key: idx }, `${it.name} x ${it.qty}`)
+            React.createElement(
+              'li',
+              { key: idx },
+              `${it.name} x ${it.qty}`,
+              it.price ? ` - $${it.price}` : ''
+            )
           )
         )
       : React.createElement('p', null, 'Cart is empty'),

--- a/src/screens/PorterScreen.js
+++ b/src/screens/PorterScreen.js
@@ -1,12 +1,14 @@
 import React from 'https://esm.sh/react@18';
 import BackButton from '../components/BackButton.js';
 
-export default function PorterScreen({ onBack }) {
+export default function PorterScreen({ onBack, onOrder }) {
   const [pickup, setPickup] = React.useState('');
   const [dropoff, setDropoff] = React.useState('');
   const [description, setDescription] = React.useState('');
   const book = () => {
-    alert(`Porter booked: ${description} from ${pickup} to ${dropoff}`);
+    if (!pickup || !dropoff || !description) return;
+    alert('Porter notified!');
+    onOrder({ name: `Porter: ${description}`, qty: 1, price: 12 });
     setPickup('');
     setDropoff('');
     setDescription('');

--- a/src/screens/TaxiScreen.js
+++ b/src/screens/TaxiScreen.js
@@ -1,14 +1,29 @@
 import React from 'https://esm.sh/react@18';
 import BackButton from '../components/BackButton.js';
 
-export default function TaxiScreen({ onBack }) {
+export default function TaxiScreen({ onBack, onOrder }) {
   const [pickup, setPickup] = React.useState('');
   const [dropoff, setDropoff] = React.useState('');
-  const book = () => {
-    alert(`Taxi booked from ${pickup} to ${dropoff}`);
+  const [showOptions, setShowOptions] = React.useState(false);
+  const vehicles = [
+    { id: 1, type: 'Sedan', price: 10 },
+    { id: 2, type: 'SUV', price: 15 },
+    { id: 3, type: 'Minivan', price: 20 }
+  ];
+
+  const search = () => {
+    if (!pickup || !dropoff) return;
+    setShowOptions(true);
+  };
+
+  const choose = v => {
+    alert(`${v.type} driver notified!`);
+    onOrder({ name: `${v.type} ride`, qty: 1, price: v.price });
     setPickup('');
     setDropoff('');
+    setShowOptions(false);
   };
+
   return React.createElement('div', null,
     BackButton({ onBack }),
     React.createElement('h2', null, 'Taxi Service'),
@@ -23,7 +38,18 @@ export default function TaxiScreen({ onBack }) {
         value: dropoff,
         onChange: e => setDropoff(e.target.value)
       }),
-      React.createElement('button', { onClick: book }, 'Book Taxi')
+      React.createElement('button', { onClick: search }, 'Find Ride')
+    ),
+    showOptions && React.createElement('div', { style: { marginTop: '1em' } },
+      React.createElement('p', null, 'Distance 5km, ETA 15min (simulated)'),
+      React.createElement('ul', null,
+        vehicles.map(v =>
+          React.createElement('li', { key: v.id },
+            `${v.type} - $${v.price} `,
+            React.createElement('button', { onClick: () => choose(v) }, 'Select')
+          )
+        )
+      )
     )
   );
 }


### PR DESCRIPTION
## Summary
- integrate price display in PaymentScreen
- add search and vehicle options for Taxi and Bike Taxi services
- notify on booking and immediately redirect to payment for all services
- enable checkoutItem handling from main app flow
- document the instant checkout behaviour

## Testing
- `npm start >/tmp/server.log &`
- `cat /tmp/server.log | head -n 5`


------
https://chatgpt.com/codex/tasks/task_e_6888a352c60c832b9de5c74f8dac429a