### PR TITLE
Add user auth API and profile screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ provides placeholder screens for:
 - Medicine delivery with quick medicine order
 - Bike taxi service with ride booking form
 - User signup and login
+- Customer profile management
 - Payment flow (simulated)
 - Simple cart with checkout
 - Order history screen
@@ -32,7 +33,7 @@ Open `index.html` in your browser to explore the different services. Each
 section is a minimal mock screen that demonstrates basic navigation between the
 home page and the individual services.
 
-Authentication remains simulated, but orders are now persisted on the backend.
+Authentication is handled via simple in-memory API endpoints, and orders are persisted on the backend.
 After checking out, the cart items are sent to `/api/orders` which stores the
 order in memory. The driver tracking screen requests location updates from your
 backend at `/api/driver`.

--- a/routes/users.js
+++ b/routes/users.js
@@ -1,0 +1,49 @@
+const express = require('express');
+const router = express.Router();
+
+// In-memory user store
+const users = {};
+
+// Sign up new user
+router.post('/signup', (req, res) => {
+  const { username, password } = req.body;
+  if (!username || !password) {
+    return res.status(400).json({ error: 'Missing fields' });
+  }
+  if (users[username]) {
+    return res.status(409).json({ error: 'User already exists' });
+  }
+  users[username] = {
+    username,
+    password,
+    profile: { location: '', currency: 'USD' }
+  };
+  res.status(201).json({ username, profile: users[username].profile });
+});
+
+// Login existing user
+router.post('/login', (req, res) => {
+  const { username, password } = req.body;
+  const user = users[username];
+  if (!user || user.password !== password) {
+    return res.status(401).json({ error: 'Invalid credentials' });
+  }
+  res.json({ username, profile: user.profile });
+});
+
+// Get user profile
+router.get('/:username', (req, res) => {
+  const user = users[req.params.username];
+  if (!user) return res.status(404).json({ error: 'User not found' });
+  res.json({ username: user.username, profile: user.profile });
+});
+
+// Update profile
+router.put('/:username', (req, res) => {
+  const user = users[req.params.username];
+  if (!user) return res.status(404).json({ error: 'User not found' });
+  user.profile = { ...user.profile, ...req.body.profile };
+  res.json({ username: user.username, profile: user.profile });
+});
+
+module.exports = router;

--- a/server.js
+++ b/server.js
@@ -5,6 +5,7 @@ const app = express();
 const restaurants = require('./routes/restaurants');
 const driver = require('./routes/driver');
 const orders = require('./routes/orders');
+const users = require('./routes/users');
 
 app.use(express.static(path.join(__dirname)));
 app.use(express.json());
@@ -12,6 +13,7 @@ app.use(express.json());
 app.use('/api/restaurants', restaurants);
 app.use('/api/driver', driver);
 app.use('/api/orders', orders);
+app.use('/api/users', users);
 
 const PORT = process.env.PORT || 3000;
 app.listen(PORT, () => {

--- a/src/main.js
+++ b/src/main.js
@@ -11,49 +11,10 @@ import PorterScreen from "./screens/PorterScreen.js";
 import MedicineScreen from "./screens/MedicineScreen.js";
 import BikeTaxiScreen from "./screens/BikeTaxiScreen.js";
 import OrdersScreen from "./screens/OrdersScreen.js";
+import SignupScreen from "./screens/SignupScreen.js";
+import LoginScreen from "./screens/LoginScreen.js";
+import ProfileScreen from "./screens/ProfileScreen.js";
 import BackButton from "./components/BackButton.js";
-
-function Signup({ onBack, onSignup }) {
-  const [username, setUsername] = React.useState('');
-  const [password, setPassword] = React.useState('');
-  return React.createElement('div', null,
-    BackButton({ onBack }),
-    React.createElement('h2', null, 'Sign Up'),
-    React.createElement('input', {
-      placeholder: 'Username',
-      value: username,
-      onChange: e => setUsername(e.target.value)
-    }),
-    React.createElement('input', {
-      placeholder: 'Password',
-      type: 'password',
-      value: password,
-      onChange: e => setPassword(e.target.value)
-    }),
-    React.createElement('button', { onClick: () => onSignup({ username }) }, 'Sign Up')
-  );
-}
-
-function Login({ onBack, onLogin }) {
-  const [username, setUsername] = React.useState('');
-  const [password, setPassword] = React.useState('');
-  return React.createElement('div', null,
-    BackButton({ onBack }),
-    React.createElement('h2', null, 'Login'),
-    React.createElement('input', {
-      placeholder: 'Username',
-      value: username,
-      onChange: e => setUsername(e.target.value)
-    }),
-    React.createElement('input', {
-      placeholder: 'Password',
-      type: 'password',
-      value: password,
-      onChange: e => setPassword(e.target.value)
-    }),
-    React.createElement('button', { onClick: () => onLogin({ username }) }, 'Login')
-  );
-}
 
 function Settings({ onBack, settings, onUpdate }) {
   const [location, setLocation] = React.useState(settings.location || '');
@@ -127,9 +88,11 @@ function App() {
 
   switch(page) {
     case 'signup':
-      return Signup({ onBack, onSignup: handleAuth });
+      return SignupScreen({ onBack, onSignup: handleAuth });
     case 'login':
-      return Login({ onBack, onLogin: handleAuth });
+      return LoginScreen({ onBack, onLogin: handleAuth });
+    case 'profile':
+      return ProfileScreen({ onBack, user, onUpdate: u => { setUser(u); setPage('home'); } });
     case 'settings':
       return Settings({ onBack, settings, onUpdate: handleSettings });
     case 'payment':

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -33,6 +33,9 @@ export default function HomeScreen({ onNavigate, user, onLogout }) {
         user ? React.createElement('li', null,
           React.createElement('button', { onClick: () => onNavigate('orders') }, 'My Orders')
         ) : null,
+        user ? React.createElement('li', null,
+          React.createElement('button', { onClick: () => onNavigate('profile') }, 'Profile')
+        ) : null,
         React.createElement('li', null,
           React.createElement('button', { onClick: () => onNavigate('settings') }, 'Settings')
         ),

--- a/src/screens/LoginScreen.js
+++ b/src/screens/LoginScreen.js
@@ -1,0 +1,42 @@
+import React from 'https://esm.sh/react@18';
+import BackButton from '../components/BackButton.js';
+
+export default function LoginScreen({ onBack, onLogin }) {
+  const [username, setUsername] = React.useState('');
+  const [password, setPassword] = React.useState('');
+
+  const handleLogin = async () => {
+    try {
+      const res = await fetch('/api/users/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username, password })
+      });
+      if (!res.ok) {
+        throw new Error('Login failed');
+      }
+      const data = await res.json();
+      onLogin({ username: data.username, profile: data.profile });
+    } catch (e) {
+      console.error(e);
+      alert('Failed to login');
+    }
+  };
+
+  return React.createElement('div', null,
+    BackButton({ onBack }),
+    React.createElement('h2', null, 'Login'),
+    React.createElement('input', {
+      placeholder: 'Username',
+      value: username,
+      onChange: e => setUsername(e.target.value)
+    }),
+    React.createElement('input', {
+      placeholder: 'Password',
+      type: 'password',
+      value: password,
+      onChange: e => setPassword(e.target.value)
+    }),
+    React.createElement('button', { onClick: handleLogin }, 'Login')
+  );
+}

--- a/src/screens/ProfileScreen.js
+++ b/src/screens/ProfileScreen.js
@@ -1,0 +1,50 @@
+import React from 'https://esm.sh/react@18';
+import BackButton from '../components/BackButton.js';
+
+export default function ProfileScreen({ onBack, user, onUpdate }) {
+  const [location, setLocation] = React.useState(user.profile?.location || '');
+  const [currency, setCurrency] = React.useState(user.profile?.currency || 'USD');
+
+  const save = async () => {
+    try {
+      const res = await fetch(`/api/users/${user.username}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ profile: { location, currency } })
+      });
+      if (!res.ok) throw new Error('Save failed');
+      const data = await res.json();
+      onUpdate({ username: data.username, profile: data.profile });
+    } catch (e) {
+      console.error(e);
+      alert('Failed to update profile');
+    }
+  };
+
+  return React.createElement('div', null,
+    BackButton({ onBack }),
+    React.createElement('h2', null, 'Customer Profile'),
+    React.createElement('div', null,
+      React.createElement('label', null, 'Username: ' + user.username)
+    ),
+    React.createElement('div', null,
+      React.createElement('label', null, 'Location:'),
+      React.createElement('input', {
+        value: location,
+        onChange: e => setLocation(e.target.value)
+      })
+    ),
+    React.createElement('div', null,
+      React.createElement('label', null, 'Currency:'),
+      React.createElement('select', {
+        value: currency,
+        onChange: e => setCurrency(e.target.value)
+      },
+        React.createElement('option', { value: 'USD' }, 'USD'),
+        React.createElement('option', { value: 'EUR' }, 'EUR'),
+        React.createElement('option', { value: 'SGD' }, 'SGD')
+      )
+    ),
+    React.createElement('button', { onClick: save }, 'Save')
+  );
+}

--- a/src/screens/SignupScreen.js
+++ b/src/screens/SignupScreen.js
@@ -1,0 +1,42 @@
+import React from 'https://esm.sh/react@18';
+import BackButton from '../components/BackButton.js';
+
+export default function SignupScreen({ onBack, onSignup }) {
+  const [username, setUsername] = React.useState('');
+  const [password, setPassword] = React.useState('');
+
+  const handleSignup = async () => {
+    try {
+      const res = await fetch('/api/users/signup', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username, password })
+      });
+      if (!res.ok) {
+        throw new Error('Signup failed');
+      }
+      const data = await res.json();
+      onSignup({ username: data.username, profile: data.profile });
+    } catch (e) {
+      console.error(e);
+      alert('Failed to sign up');
+    }
+  };
+
+  return React.createElement('div', null,
+    BackButton({ onBack }),
+    React.createElement('h2', null, 'Sign Up'),
+    React.createElement('input', {
+      placeholder: 'Username',
+      value: username,
+      onChange: e => setUsername(e.target.value)
+    }),
+    React.createElement('input', {
+      placeholder: 'Password',
+      type: 'password',
+      value: password,
+      onChange: e => setPassword(e.target.value)
+    }),
+    React.createElement('button', { onClick: handleSignup }, 'Sign Up')
+  );
+}


### PR DESCRIPTION
## Summary
- add in-memory user routes for signup, login, and profile
- integrate user routes in server
- add Login, Signup and Profile screens
- update Home screen navigation
- wire auth screens into app routing
- update README to mention profile and new authentication flow

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6888ac3e311c832ba8a70de2a188a824