### PR TITLE
Rename app references to grap

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Grap Frontend
+# grap Frontend
 
-This is a simple single page application that mimics a Grab style user flow. It
+This is a simple single page application that mimics a grap style user flow. It
 provides placeholder screens for:
 
 - Restaurant delivery with backend data

--- a/expo/App.js
+++ b/expo/App.js
@@ -10,7 +10,7 @@ function BackButton({ onBack }) {
 function Home({ navigation, user, onLogout }) {
   return (
     <View style={styles.container}>
-      <Text style={styles.title}>Grab Style App</Text>
+      <Text style={styles.title}>grap</Text>
       {user && <Text>Welcome, {user.username}</Text>}
       <Button title="Restaurant Delivery" onPress={() => navigation.navigate('Food')} />
       <Button title="Taxi Service" onPress={() => navigation.navigate('Taxi')} />

--- a/expo/README.md
+++ b/expo/README.md
@@ -1,4 +1,4 @@
-# Expo Version of Grap Frontend
+# Expo Version of grap Frontend
 
 This folder contains a minimal Expo project that mirrors the single page web app. Each service screen is written in React Native so you can run the flow on a mobile device using Expo.
 

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Grab Style App</title>
+  <title>grap</title>
   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
     integrity="sha512-sA+e3Ac9PWEo9PteodTkyYtqt0Wvy6l+Hp1oD7wM0I1ylcImfX1xPtYjO9DRyO3XBBO8rHQDB5GUYIg6B91tWA=="
     crossorigin=""/>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grapfrontend-server",
   "version": "1.0.0",
-  "description": "Backend server for Grap Frontend demo",
+  "description": "Backend server for grap frontend demo",
   "main": "server.js",
   "scripts": {
     "start": "node server.js"

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -3,7 +3,7 @@ import React from 'https://esm.sh/react@18';
 export default function HomeScreen({ onNavigate, user, onLogout }) {
   return (
     React.createElement('div', null,
-      React.createElement('h1', null, 'Grab Style App'),
+      React.createElement('h1', null, 'grap'),
       user ? React.createElement('p', null, `Welcome, ${user.username}`) : null,
       React.createElement('ul', null,
         React.createElement('li', null,


### PR DESCRIPTION
## Summary
- rename app in README and Expo docs
- update app title in index.html, HomeScreen, and Expo app
- refresh package description

## Testing
- `node --check server.js`
- `npm install`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6888ae80e03c832b866dd76132964fdd