### PR TITLE
Fix Metro plugin error

### DIFF
--- a/expo/package.json
+++ b/expo/package.json
@@ -4,12 +4,19 @@
   "main": "App.js",
   "private": true,
   "dependencies": {
+    "@react-navigation/native": "^6.1.8",
+    "@react-navigation/native-stack": "^6.9.12",
     "expo": "^49.0.0",
     "react": "18.2.0",
     "react-native": "0.72.0",
-    "@react-navigation/native": "^6.1.8",
-    "@react-navigation/native-stack": "^6.9.12",
-    "react-native-screens": "^3.29.0",
-    "react-native-safe-area-context": "^4.8.0"
+    "react-native-safe-area-context": "^4.8.0",
+    "react-native-screens": "^3.29.0"
+  },
+  "devDependencies": {
+    "metro": "^0.76.5",
+    "patch-package": "^8.0.0"
+  },
+  "scripts": {
+    "postinstall": "patch-package"
   }
 }

--- a/expo/patches/metro+0.76.5.patch
+++ b/expo/patches/metro+0.76.5.patch
@@ -1,0 +1,52 @@
+diff --git a/node_modules/metro/src/ModuleGraph/worker/importLocationsPlugin.js b/node_modules/metro/src/ModuleGraph/worker/importLocationsPlugin.js
+new file mode 100644
+index 0000000..82789a5
+--- /dev/null
++++ b/node_modules/metro/src/ModuleGraph/worker/importLocationsPlugin.js
+@@ -0,0 +1,46 @@
++"use strict";
++
++function importLocationsPlugin({ types: t }) {
++  return {
++    visitor: {
++      ImportDeclaration(path, { importDeclarationLocs }) {
++        if (path.node.importKind !== "type" && path.node.loc != null) {
++          importDeclarationLocs.add(locToKey(path.node.loc));
++        }
++      },
++      ExportDeclaration(path, { importDeclarationLocs }) {
++        if (
++          path.node.source != null &&
++          path.node.exportKind !== "type" &&
++          path.node.loc != null
++        ) {
++          importDeclarationLocs.add(locToKey(path.node.loc));
++        }
++      },
++      Program(path, state) {
++        state.importDeclarationLocs = new Set();
++        const metroMetadata = state.file.metadata;
++        if (!metroMetadata.metro) {
++          metroMetadata.metro = {
++            unstable_importDeclarationLocs: state.importDeclarationLocs,
++          };
++        } else {
++          metroMetadata.metro.unstable_importDeclarationLocs =
++            state.importDeclarationLocs;
++        }
++      },
++    },
++  };
++}
++const MISSING_LOC = {
++  line: -1,
++  column: -1,
++};
++function locToKey(loc) {
++  const { start = MISSING_LOC, end = MISSING_LOC } = loc;
++  return `${start.line},${start.column}:${end.line},${end.column}`;
++}
++module.exports = {
++  importLocationsPlugin,
++  locToKey,
++};


### PR DESCRIPTION
## Summary
- add patch-package and Metro patch with importLocationsPlugin
- patch Metro after installs to include importLocationsPlugin

## Testing
- `npm install`
- `npx expo start --clear` (shows Metro Bundler startup without errors)


------
https://chatgpt.com/codex/tasks/task_e_6888c8ba4814832bbf11efbedbccd141