### PR TITLE
Add theme toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ provides placeholder screens for:
 - Simple cart with checkout
 - Order history screen
 - Interactive driver location tracking map
-- Customer settings for location and currency
+- Customer settings for location, currency and theme (light/dark)
 
 Items selected from the service screens can be added to a small in-memory cart.
 The cart page allows reviewing items and leads to the simulated payment flow.

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>grap</title>
+  <link rel="stylesheet" href="./src/style.css">
   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
     integrity="sha512-sA+e3Ac9PWEo9PteodTkyYtqt0Wvy6l+Hp1oD7wM0I1ylcImfX1xPtYjO9DRyO3XBBO8rHQDB5GUYIg6B91tWA=="
     crossorigin=""/>

--- a/src/main.js
+++ b/src/main.js
@@ -19,6 +19,7 @@ import BackButton from "./components/BackButton.js";
 function Settings({ onBack, settings, onUpdate }) {
   const [location, setLocation] = React.useState(settings.location || '');
   const [currency, setCurrency] = React.useState(settings.currency || 'USD');
+  const [theme, setTheme] = React.useState(settings.theme || 'light');
   return React.createElement('div', null,
     BackButton({ onBack }),
     React.createElement('h2', null, 'Customer Settings'),
@@ -37,11 +38,21 @@ function Settings({ onBack, settings, onUpdate }) {
       },
         React.createElement('option', { value: 'USD' }, 'USD'),
         React.createElement('option', { value: 'EUR' }, 'EUR'),
-        React.createElement('option', { value: 'SGD' }, 'SGD')
+      React.createElement('option', { value: 'SGD' }, 'SGD')
+      )
+    ),
+    React.createElement('div', null,
+      React.createElement('label', null, 'Theme:'),
+      React.createElement('select', {
+        value: theme,
+        onChange: e => setTheme(e.target.value)
+      },
+        React.createElement('option', { value: 'light' }, 'Light'),
+        React.createElement('option', { value: 'dark' }, 'Dark')
       )
     ),
     React.createElement('button', {
-      onClick: () => onUpdate({ location, currency })
+      onClick: () => onUpdate({ location, currency, theme })
     }, 'Save')
   );
 }
@@ -73,8 +84,12 @@ function Cart({ onBack, items, onCheckout, onRemove }) {
 function App() {
   const [page, setPage] = React.useState('home');
   const [user, setUser] = React.useState(null);
-  const [settings, setSettings] = React.useState({ location: '', currency: 'USD' });
+  const [settings, setSettings] = React.useState({ location: '', currency: 'USD', theme: 'light' });
   const [cart, setCart] = React.useState([]);
+
+  React.useEffect(() => {
+    document.body.dataset.theme = settings.theme || 'light';
+  }, [settings.theme]);
 
   const addToCart = item => setCart(c => [...c, item]);
   const removeFromCart = idx => setCart(c => c.filter((_, i) => i !== idx));

--- a/src/style.css
+++ b/src/style.css
@@ -1,0 +1,15 @@
+body {
+  margin: 0;
+  font-family: sans-serif;
+}
+body[data-theme='dark'] {
+  background-color: #222;
+  color: #eee;
+}
+body[data-theme='light'] {
+  background-color: #fff;
+  color: #000;
+}
+button {
+  margin: 4px;
+}


### PR DESCRIPTION
## Summary
- support light/dark theme selection in settings
- apply the selected theme on the document body
- add basic styles

## Testing
- `npm install`
- `npm start` *(fails: [Ctrl+C to stop])*

------
https://chatgpt.com/codex/tasks/task_e_6888d52b2cdc832bb4510cce2027ef57