### PR TITLE
Add 2025 theme and update mobile styles

### DIFF
--- a/expo/App.js
+++ b/expo/App.js
@@ -10,8 +10,8 @@ function BackButton({ onBack }) {
 function Home({ navigation, user, onLogout }) {
   return (
     <View style={styles.container}>
-      <Text style={styles.title}>grap</Text>
-      {user && <Text>Welcome, {user.username}</Text>}
+      <Text style={styles.title}>grap 2025</Text>
+      {user && <Text style={styles.text}>Welcome, {user.username}</Text>}
       <Button title="Restaurant Delivery" onPress={() => navigation.navigate('Food')} />
       <Button title="Taxi Service" onPress={() => navigation.navigate('Taxi')} />
       <Button title="Mart Delivery" onPress={() => navigation.navigate('Mart')} />
@@ -90,11 +90,11 @@ function Payment({ navigation, items, onPay }) {
           data={items}
           keyExtractor={(_, i) => String(i)}
           renderItem={({ item }) => (
-            <Text>{item.name} x {item.qty}</Text>
+            <Text style={styles.text}>{item.name} x {item.qty}</Text>
           )}
         />
       ) : (
-        <Text>Cart is empty</Text>
+        <Text style={styles.text}>Cart is empty</Text>
       )}
       <Button title="Pay Now" disabled={!items.length} onPress={() => { alert('Payment completed (simulated).'); onPay(); navigation.goBack(); }} />
     </View>
@@ -112,13 +112,13 @@ function Cart({ navigation, items, onCheckout, onRemove }) {
           keyExtractor={(_, i) => String(i)}
           renderItem={({ item, index }) => (
             <View style={{ flexDirection: 'row', alignItems: 'center' }}>
-              <Text style={{ marginRight: 8 }}>{item.name} x {item.qty}</Text>
+              <Text style={[styles.text, { marginRight: 8 }]}>{item.name} x {item.qty}</Text>
               <Button title="Remove" onPress={() => onRemove(index)} />
             </View>
           )}
         />
       ) : (
-        <Text>Cart is empty</Text>
+        <Text style={styles.text}>Cart is empty</Text>
       )}
       <Button title="Checkout" disabled={!items.length} onPress={() => onCheckout()} />
     </View>
@@ -144,8 +144,8 @@ function OrderTracking({ navigation }) {
     <View style={styles.container}>
       <BackButton onBack={() => navigation.goBack()} />
       <Text style={styles.subtitle}>Driver Position</Text>
-      <Text>Lat: {position.lat.toFixed(5)}</Text>
-      <Text>Lng: {position.lng.toFixed(5)}</Text>
+      <Text style={styles.text}>Lat: {position.lat.toFixed(5)}</Text>
+      <Text style={styles.text}>Lng: {position.lng.toFixed(5)}</Text>
     </View>
   );
 }
@@ -174,7 +174,7 @@ function FoodDelivery({ navigation, onAdd }) {
         keyExtractor={item => String(item.id)}
         renderItem={({ item }) => (
           <View style={{ flexDirection: 'row', alignItems: 'center' }}>
-            <Text style={{ marginRight: 8 }}>{item.name}</Text>
+            <Text style={[styles.text, { marginRight: 8 }]}>{item.name}</Text>
             <Button title="Add" onPress={() => onAdd({ name: item.name, qty: 1 })} />
           </View>
         )}
@@ -315,24 +315,28 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
     padding: 16,
-    backgroundColor: '#fff'
+    backgroundColor: '#0f172a'
   },
   title: {
-    fontSize: 24,
+    fontSize: 26,
     fontWeight: 'bold',
     marginBottom: 16,
-    color: '#00b14f'
+    color: '#38bdf8'
   },
   subtitle: {
-    fontSize: 20,
+    fontSize: 22,
     marginVertical: 12,
-    color: '#00b14f'
+    color: '#38bdf8'
+  },
+  text: {
+    color: '#e2e8f0'
   },
   input: {
     borderWidth: 1,
-    borderColor: '#ccc',
+    borderColor: '#555',
     padding: 8,
     width: '80%',
-    marginVertical: 4
+    marginVertical: 4,
+    color: '#e2e8f0'
   }
 });

--- a/index.html
+++ b/index.html
@@ -3,7 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>grap</title>
+  <title>grap 2025</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="./src/style.css">
   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
     integrity="sha512-sA+e3Ac9PWEo9PteodTkyYtqt0Wvy6l+Hp1oD7wM0I1ylcImfX1xPtYjO9DRyO3XBBO8rHQDB5GUYIg6B91tWA=="

--- a/src/main.js
+++ b/src/main.js
@@ -19,7 +19,7 @@ import BackButton from "./components/BackButton.js";
 function Settings({ onBack, settings, onUpdate }) {
   const [location, setLocation] = React.useState(settings.location || '');
   const [currency, setCurrency] = React.useState(settings.currency || 'USD');
-  const [theme, setTheme] = React.useState(settings.theme || 'light');
+  const [theme, setTheme] = React.useState(settings.theme || 'future');
   return React.createElement('div', null,
     BackButton({ onBack }),
     React.createElement('h2', null, 'Customer Settings'),
@@ -48,7 +48,8 @@ function Settings({ onBack, settings, onUpdate }) {
         onChange: e => setTheme(e.target.value)
       },
         React.createElement('option', { value: 'light' }, 'Light'),
-        React.createElement('option', { value: 'dark' }, 'Dark')
+        React.createElement('option', { value: 'dark' }, 'Dark'),
+        React.createElement('option', { value: 'future' }, 'Future 2025')
       )
     ),
     React.createElement('button', {
@@ -84,11 +85,11 @@ function Cart({ onBack, items, onCheckout, onRemove }) {
 function App() {
   const [page, setPage] = React.useState('home');
   const [user, setUser] = React.useState(null);
-  const [settings, setSettings] = React.useState({ location: '', currency: 'USD', theme: 'light' });
+  const [settings, setSettings] = React.useState({ location: '', currency: 'USD', theme: 'future' });
   const [cart, setCart] = React.useState([]);
 
   React.useEffect(() => {
-    document.body.dataset.theme = settings.theme || 'light';
+    document.body.dataset.theme = settings.theme || 'future';
   }, [settings.theme]);
 
   const addToCart = item => setCart(c => [...c, item]);

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -3,7 +3,7 @@ import React from 'https://esm.sh/react@18';
 export default function HomeScreen({ onNavigate, user, onLogout }) {
   return (
     React.createElement('div', null,
-      React.createElement('h1', null, 'grap'),
+      React.createElement('h1', null, 'grap 2025'),
       user ? React.createElement('p', null, `Welcome, ${user.username}`) : null,
       React.createElement('ul', null,
         React.createElement('li', null,

--- a/src/style.css
+++ b/src/style.css
@@ -1,6 +1,6 @@
 body {
   margin: 0;
-  font-family: sans-serif;
+  font-family: 'Inter', sans-serif;
 }
 body[data-theme='dark'] {
   background-color: #222;
@@ -9,6 +9,21 @@ body[data-theme='dark'] {
 body[data-theme='light'] {
   background-color: #fff;
   color: #000;
+}
+body[data-theme='future'] {
+  background: linear-gradient(135deg, #0f2027, #203a43, #2c5364);
+  color: #e0f2ff;
+}
+body[data-theme='future'] h1,
+body[data-theme='future'] h2 {
+  color: #38bdf8;
+}
+body[data-theme='future'] button {
+  background-color: #1e3a8a;
+  color: #fff;
+  border: none;
+  padding: 8px 12px;
+  border-radius: 4px;
 }
 button {
   margin: 4px;


### PR DESCRIPTION
## Summary
- refresh HTML title and add Google font
- introduce a futuristic `future` theme with gradient background
- make `future` the default theme in React web app
- update HomeScreen and Expo app branding to `grap 2025`
- restyle Expo components with a modern dark palette

## Testing
- `npm install --ignore-scripts`
- `cd expo && npm install --ignore-scripts`

------
https://chatgpt.com/codex/tasks/task_e_6888d638661c832bae543262337986ac